### PR TITLE
feat: add meeting data table display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "dotenv": "^16.5.0",
         "drizzle-orm": "^0.43.1",
         "embla-carousel-react": "^8.6.0",
+        "humanize-duration": "^3.33.0",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.539.0",
         "nanoid": "^5.1.5",
@@ -75,6 +76,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
+        "@types/humanize-duration": "^3.27.4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -4357,6 +4359,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/humanize-duration": {
+      "version": "3.27.4",
+      "resolved": "https://registry.npmjs.org/@types/humanize-duration/-/humanize-duration-3.27.4.tgz",
+      "integrity": "sha512-yaf7kan2Sq0goxpbcwTQ+8E9RP6HutFBPv74T/IA/ojcHKhuKVlk2YFYyHhWZeLvZPzzLE3aatuQB4h0iqyyUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4394,7 +4403,7 @@
       "version": "19.1.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
       "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4404,7 +4413,7 @@
       "version": "19.1.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -7238,6 +7247,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/humanize-duration": {
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.33.0.tgz",
+      "integrity": "sha512-vYJX7BSzn7EQ4SaP2lPYVy+icHDppB6k7myNeI3wrSRfwMS5+BHyGgzpHR0ptqJ2AQ6UuIKrclSg5ve6Ci4IAQ==",
+      "license": "Unlicense"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "dotenv": "^16.5.0",
     "drizzle-orm": "^0.43.1",
     "embla-carousel-react": "^8.6.0",
+    "humanize-duration": "^3.33.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.539.0",
     "nanoid": "^5.1.5",
@@ -78,6 +79,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/humanize-duration": "^3.27.4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -27,7 +27,7 @@ export function DataTable<TData, TValue>({
   });
 
   return (
-    <div className="overflow-hidden rounded-lg border bg-background">
+    <div className="rounded-lg border bg-background overflow-hidden">
       <Table>
         <TableBody>
           {table.getRowModel().rows?.length ? (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,15 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from 'clsx';
+import humanizeDuration from 'humanize-duration';
+import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
+}
+
+export function formatDuration(seconds: number) {
+  return humanizeDuration(seconds * 1000, {
+    largest: 1,
+    round: true,
+    units: ['h', 'm', 's'],
+  });
 }

--- a/src/modules/agents/types.ts
+++ b/src/modules/agents/types.ts
@@ -2,4 +2,6 @@ import { inferRouterOutputs } from '@trpc/server';
 
 import type { AppRouter } from '@/trpc/routers/_app';
 
+export type AgentsGetMany =
+  inferRouterOutputs<AppRouter>['agents']['getMany']['items'];
 export type AgentGetOne = inferRouterOutputs<AppRouter>['agents']['getOne'];

--- a/src/modules/agents/ui/components/columns.tsx
+++ b/src/modules/agents/ui/components/columns.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { ColumnDef } from '@tanstack/react-table';
-import { AgentGetOne } from '../../types';
+import { AgentsGetMany } from '../../types';
 import { GeneratedAvatar } from '@/components/generated-avatar';
 import { CornerDownRightIcon, VideoIcon } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 
-export const columns: ColumnDef<AgentGetOne>[] = [
+export const columns: ColumnDef<AgentsGetMany[number]>[] = [
   {
     accessorKey: 'name',
     header: 'Agent Name',

--- a/src/modules/agents/ui/views/agents-view.tsx
+++ b/src/modules/agents/ui/views/agents-view.tsx
@@ -4,7 +4,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { useTRPC } from '@/trpc/client';
 import { LoadingState } from '@/components/loading-state';
 import { ErrorState } from '@/components/error-state';
-import { DataTable } from '../components/data-table';
+import { DataTable } from '@/components/data-table';
 import { columns } from '../components/columns';
 import { EmptyState } from '@/components/empty-state';
 import { useAgentsFilters } from '../../hooks/use-agents-filters';

--- a/src/modules/meetings/server/procedures.ts
+++ b/src/modules/meetings/server/procedures.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
-import { and, count, desc, eq, getTableColumns, ilike } from 'drizzle-orm';
+import { and, count, desc, eq, getTableColumns, ilike, sql } from 'drizzle-orm';
 
 import { db } from '@/db';
-import { meetings } from '@/db/schema';
+import { agents, meetings } from '@/db/schema';
 import { createTRPCRouter, protectedProcedure } from '@/trpc/init';
 import {
   DEFAULT_PAGE,
@@ -105,8 +105,13 @@ export const meetingsRouter = createTRPCRouter({
       const data = await db
         .select({
           ...getTableColumns(meetings),
+          agent: agents,
+          duration: sql<number>`EXTRACT(EPOCH FROM (ended_at - started_at))`.as(
+            'duration'
+          ),
         })
         .from(meetings)
+        .innerJoin(agents, eq(meetings.agentId, agents.id))
         .where(
           and(
             eq(meetings.userId, ctx.auth.user.id),
@@ -120,6 +125,7 @@ export const meetingsRouter = createTRPCRouter({
       const [total] = await db
         .select({ count: count() })
         .from(meetings)
+        .innerJoin(agents, eq(meetings.agentId, agents.id))
         .where(
           and(
             eq(meetings.userId, ctx.auth.user.id),

--- a/src/modules/meetings/ui/components/columns.tsx
+++ b/src/modules/meetings/ui/components/columns.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { format } from 'date-fns';
+import { ColumnDef } from '@tanstack/react-table';
+import {
+  CircleCheckIcon,
+  CircleXIcon,
+  ClockArrowUpIcon,
+  ClockFadingIcon,
+  CornerDownRightIcon,
+  LoaderIcon,
+} from 'lucide-react';
+
+import { cn, formatDuration } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+import { GeneratedAvatar } from '@/components/generated-avatar';
+
+import { MeetingGetMany } from '../../types';
+
+const statusIconMap = {
+  upcoming: ClockArrowUpIcon,
+  active: LoaderIcon,
+  completed: CircleCheckIcon,
+  processing: LoaderIcon,
+  cancelled: CircleXIcon,
+};
+
+const statusColorMap = {
+  upcoming: 'bg-yellow-500/20 text-yellow-800 border-yellow-800/5',
+  active: 'bg-blue-500/20 text-blue-800 border-blue-800/5',
+  completed: 'bg-emerald-500/20 text-emerald-800 border-emerald-800/5',
+  cancelled: 'bg-rose-500/20 text-rose-800 border-rose-800/5',
+  processing: 'bg-gray-300/20 text-gray-800 border-gray-800/5',
+};
+
+export const columns: ColumnDef<MeetingGetMany[number]>[] = [
+  {
+    accessorKey: 'name',
+    header: 'Meeting Name',
+    cell: ({ row }) => (
+      <div className="flex flex-col gap-y-1">
+        <span className="font-semibold capitalize">{row.original.name}</span>
+        <div className="flex items-center gap-x-2">
+          <div className="flex items-center gap-x-1">
+            <CornerDownRightIcon className="size-3 text-muted-foreground" />
+            <span className="text-sm text-muted-foreground max-w-[200px] truncate capitalize">
+              {row.original.agent.name}
+            </span>
+          </div>
+          <GeneratedAvatar
+            variant="botttsNeutral"
+            seed={row.original.agent.name}
+            className="size-4"
+          />
+          <span className="text-sm text-muted-foreground">
+            {row.original.startedAt
+              ? format(row.original.startedAt, 'MMM d')
+              : ''}
+          </span>
+        </div>
+      </div>
+    ),
+  },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    cell: ({ row }) => {
+      const Icon =
+        statusIconMap[row.original.status as keyof typeof statusIconMap];
+
+      return (
+        <Badge
+          variant="outline"
+          className={cn(
+            'capitalize [&>svg]:size-4 text-muted-foreground',
+            statusColorMap[row.original.status as keyof typeof statusColorMap]
+          )}
+        >
+          <Icon
+            className={cn(
+              row.original.status === 'processing' && 'animate-spin'
+            )}
+          />
+          {row.original.status}
+        </Badge>
+      );
+    },
+  },
+  {
+    accessorKey: 'duration',
+    header: 'duration',
+    cell: ({ row }) => (
+      <Badge
+        variant="outline"
+        className="capitalize [&>svg]:size-4 flex items-center gap-x-2"
+      >
+        <ClockFadingIcon className="text-blue-700" />
+        {row.original.duration
+          ? formatDuration(row.original.duration)
+          : 'No duration'}
+      </Badge>
+    ),
+  },
+];

--- a/src/modules/meetings/ui/components/new-meeting-dialog.tsx
+++ b/src/modules/meetings/ui/components/new-meeting-dialog.tsx
@@ -25,7 +25,7 @@ export const NewMeetingDialog = ({
           onOpenChange(false);
           router.push(`/meetings/${id}`);
         }}
-        onCancel={() => onOpenChange}
+        onCancel={() => onOpenChange(false)}
       />
     </ResponsiveDialog>
   );

--- a/src/modules/meetings/ui/views/meetings-view.tsx
+++ b/src/modules/meetings/ui/views/meetings-view.tsx
@@ -5,18 +5,32 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { ErrorState } from '@/components/error-state';
 import { LoadingState } from '@/components/loading-state';
+import { DataTable } from '@/components/data-table';
+import { columns } from '../components/columns';
+import { EmptyState } from '@/components/empty-state';
 
 export const MeetingView = () => {
   const trpc = useTRPC();
   const { data } = useSuspenseQuery(trpc.meetings.getMany.queryOptions({}));
-  return <div>TODO: Data table</div>;
+
+  return (
+    <div className="flex-1 pb-4 px-4 md:px-8 flex flex-col gap-y-4">
+      <DataTable data={data.items} columns={columns} />
+      {data.items.length === 0 && (
+        <EmptyState
+          title="Create your first meeting"
+          description="Schedule a meeting to connect with others. Each meeting lets you collaborate, share ideas, and interact with participants in real time."
+        />
+      )}
+    </div>
+  );
 };
 
 export const MeetingsViewLoading = () => {
   return (
     <LoadingState
       title="Loading Meetings"
-      description="This may take a fews seconds"
+      description="This may take a few seconds"
     />
   );
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a Meetings table with columns for meeting name, agent, status, start date, and duration.
  - Status now displays with icons and color-coded badges; processing shows a spinning icon.
  - Duration is shown in a concise, human-readable format.
  - Empty state appears when there are no meetings.
  - Added a dedicated error view for meeting load failures.

- Bug Fixes
  - Canceling the New Meeting dialog now properly closes it.
  - Corrected a typo in the loading message.

- Chores
  - Added duration-formatting dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->